### PR TITLE
heap/non-heap memory as a percentage of committed

### DIFF
--- a/src/main/java/org/wikimedia/cassandra/metrics/JmxCollector.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/JmxCollector.java
@@ -122,8 +122,8 @@ public class JmxCollector implements AutoCloseable {
         // Memory
         MemoryMXBean memory = ManagementFactory.newPlatformMXBeanProxy(getConnection(), MEMORY_MXBEAN_NAME, MemoryMXBean.class);
         ObjectName oName = newObjectName(MEMORY_MXBEAN_NAME);
-        double nonHeapUsed = ((double)memory.getNonHeapMemoryUsage().getUsed() / (double)memory.getNonHeapMemoryUsage().getMax());
-        double heapUsed = ((double)memory.getHeapMemoryUsage().getUsed() / (double)memory.getHeapMemoryUsage().getMax());
+        double nonHeapUsed = ((double)memory.getNonHeapMemoryUsage().getUsed() / (double)memory.getNonHeapMemoryUsage().getCommitted());
+        double heapUsed = ((double)memory.getHeapMemoryUsage().getUsed() / (double)memory.getHeapMemoryUsage().getCommitted());
         visitor.visit(new JmxSample(Type.JVM, oName, "non_heap_usage", nonHeapUsed, timestamp));
         visitor.visit(new JmxSample(Type.JVM, oName, "heap_usage", heapUsed, timestamp));
 

--- a/src/main/java/org/wikimedia/cassandra/metrics/JmxCollector.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/JmxCollector.java
@@ -125,6 +125,7 @@ public class JmxCollector implements AutoCloseable {
         double nonHeapUsed = ((double)memory.getNonHeapMemoryUsage().getUsed() / (double)memory.getNonHeapMemoryUsage().getCommitted());
         double heapUsed = ((double)memory.getHeapMemoryUsage().getUsed() / (double)memory.getHeapMemoryUsage().getCommitted());
         visitor.visit(new JmxSample(Type.JVM, oName, "non_heap_usage", nonHeapUsed, timestamp));
+        visitor.visit(new JmxSample(Type.JVM, oName, "non_heap_usage_bytes", (double)memory.getNonHeapMemoryUsage().getUsed(), timestamp));
         visitor.visit(new JmxSample(Type.JVM, oName, "heap_usage", heapUsed, timestamp));
 
         // Garbage collection


### PR DESCRIPTION
Memory utilization (heap and non-heap) has been calculated as a percentage of
the maximum, this was lifted from the Dropwizard Metrics code this project
replaced.  However, on our JDK 8 installations, `max' for NonHeapUsage is
undefined (-1), resulting in obviously wrong values.

Committed seems a better divisor here because a) according the contract it will
always be defined, and b) of the two it represents the only guarantee of how
much memory is available.

Bug: https://phabricator.wikimedia.org/T101764