### PR TITLE
metric blacklisting

### DIFF
--- a/filter-sample.yaml
+++ b/filter-sample.yaml
@@ -1,0 +1,4 @@
+blacklist:
+  - .*\.meanRate$
+  - .*\.50percentile$
+  - .*\.999percentile$

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
       <artifactId>quartz-jobs</artifactId>
       <version>2.2.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.16</version>
+    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/org/wikimedia/cassandra/metrics/CarbonVisitor.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/CarbonVisitor.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import javax.management.ObjectName;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 
 
@@ -34,6 +35,7 @@ import com.google.common.base.Splitter;
  */
 public class CarbonVisitor implements SampleVisitor, AutoCloseable {
     private final String prefix;
+    private final Optional<Filter> filter;
 
     private CarbonConnector connector;
     private boolean isClosed = false;
@@ -50,27 +52,51 @@ public class CarbonVisitor implements SampleVisitor, AutoCloseable {
      *            string to prefix to each metric name
      */
     public CarbonVisitor(String host, int port, String prefix) {
-        this(new CarbonConnector(host, port), prefix);
+        this(new CarbonConnector(host, port), prefix, Optional.<Filter>absent());
     }
 
     /**
-     * Create a new {@link CarbonVisitor} using the supplied {@link CarbonConnector}.
+     * Create a new {@link CarbonVisitor} using the supplied host, port, and
+     * prefix.
+     * 
+     * @param host
+     *            Graphite host to connect to
+     * @param port
+     *            the Graphite port number
+     * @param prefix
+     *            string to prefix to each metric name
+     * @param filter
+     *            an {@link Optional} filter object used to determine which
+     *            metrics to accept/reject.
+     */
+    public CarbonVisitor(String host, int port, String prefix, Optional<Filter> filter) {
+        this(new CarbonConnector(host, port), prefix, filter);
+    }
+
+    /**
+     * Create a new {@link CarbonVisitor} using the supplied
+     * {@link CarbonConnector}.
      * 
      * @param carbon
      *            Carbon connector instance
      * @param prefix
      *            string to prefix to each metric name
+     * @param filter
+     *            an {@link Optional} filter object used to determine which
+     *            metrics to accept/reject.
      */
-    public CarbonVisitor(CarbonConnector carbon, String prefix) {
+    public CarbonVisitor(CarbonConnector carbon, String prefix, Optional<Filter> filter) {
         this.connector = checkNotNull(carbon, "carbon argument");
         this.prefix = checkNotNull(prefix, "prefix argument");
+        this.filter = checkNotNull(filter, "filter argument");
     }
-    
+
     /** {@inheritDoc} */
     @Override
     public void visit(JmxSample jmxSample) {
         checkState(!this.isClosed, "cannot write to closed object");
-        this.connector.write(metricName(jmxSample, this.prefix), jmxSample.getValue(), jmxSample.getTimestamp());
+        String name = metricName(jmxSample, this.prefix);
+        if (accept(name)) this.connector.write(name, jmxSample.getValue(), jmxSample.getTimestamp());
     }
 
     /**
@@ -86,6 +112,15 @@ public class CarbonVisitor implements SampleVisitor, AutoCloseable {
     @Override
     public String toString() {
         return "CarbonVisitor [carbonConnector=" + connector + ", prefix=" + prefix + ", isClosed=" + isClosed + "]";
+    }
+
+    // Convenience method; Wraps filter to provide Optional handling
+    private boolean accept(String name) {
+        // When no filter is supplied, then default to accepting everything.
+        if (this.filter.isPresent()) {
+            return this.filter.get().accept(name);
+        }
+        return true;
     }
 
     // There doesn't seem to be a deterministic way to translate these JMX resources to Graphite

--- a/src/main/java/org/wikimedia/cassandra/metrics/CarbonVisitor.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/CarbonVisitor.java
@@ -17,9 +17,6 @@ package org.wikimedia.cassandra.metrics;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static org.wikimedia.cassandra.metrics.Constants.DEFAULT_GRAPHITE_HOST;
-import static org.wikimedia.cassandra.metrics.Constants.DEFAULT_GRAPHITE_PORT;
-import static org.wikimedia.cassandra.metrics.Constants.DEFAULT_GRAPHITE_PREFIX;
 
 import java.io.IOException;
 import java.util.List;
@@ -42,38 +39,6 @@ public class CarbonVisitor implements SampleVisitor, AutoCloseable {
     private boolean isClosed = false;
 
     /**
-     * Create a new {@link CarbonVisitor} using the default host, port, and
-     * prefix.
-     */
-    public CarbonVisitor() {
-        this(DEFAULT_GRAPHITE_HOST);
-    }
-
-    /**
-     * Create a new {@link CarbonVisitor} with the supplied host, and the
-     * default port and prefix.
-     * 
-     * @param host
-     *            the Graphite host to connect to
-     */
-    public CarbonVisitor(String host) {
-        this(host, DEFAULT_GRAPHITE_PORT);
-    }
-
-    /**
-     * Create a new {@link CarbonVisitor} with the supplied host and port, and
-     * the default prefix.
-     * 
-     * @param host
-     *            Graphite host to connect to
-     * @param port
-     *            the Graphite port number
-     */
-    public CarbonVisitor(String host, int port) {
-        this(host, port, DEFAULT_GRAPHITE_PREFIX);
-    }
-
-    /**
      * Create a new {@link CarbonVisitor} using the supplied host, port, and
      * prefix.
      * 
@@ -85,12 +50,7 @@ public class CarbonVisitor implements SampleVisitor, AutoCloseable {
      *            string to prefix to each metric name
      */
     public CarbonVisitor(String host, int port, String prefix) {
-        checkNotNull(host, "host argument");
-        checkNotNull(port, "port argument");
-        this.prefix = checkNotNull(prefix, "prefix argument");
-
-        this.connector = new CarbonConnector(host, port);
-
+        this(new CarbonConnector(host, port), prefix);
     }
 
     /**

--- a/src/main/java/org/wikimedia/cassandra/metrics/Filter.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/Filter.java
@@ -1,0 +1,58 @@
+/* Copyright 2015 Eric Evans <eevans@wikimedia.org> and Wikimedia Foundation
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wikimedia.cassandra.metrics;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+public class Filter {
+
+    private List<Pattern> blacklist;
+    
+    public Filter(FilterConfig config) {
+        blacklist = Lists.newArrayList(
+            Iterables.transform(config.getBlacklist(), new Function<String, Pattern>() {
+                @Override
+                public Pattern apply(String input) {
+                     return Pattern.compile(input);
+                }
+            })
+        );
+
+    }
+
+    private boolean blackListed(String id) {
+        for (Pattern p : blacklist) {
+            if (p.matcher(id).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean accept(String id) {
+        return !blackListed(id);
+    }
+
+    @Override
+    public String toString() {
+        return "Filter [blacklist=" + blacklist + "]";
+    }
+
+}

--- a/src/main/java/org/wikimedia/cassandra/metrics/FilterConfig.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/FilterConfig.java
@@ -1,0 +1,35 @@
+/* Copyright 2015 Eric Evans <eevans@wikimedia.org> and Wikimedia Foundation
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wikimedia.cassandra.metrics;
+
+import java.util.Collection;
+
+public class FilterConfig {
+    private Collection<String> blacklist;
+
+    public Collection<String> getBlacklist() {
+        return blacklist;
+    }
+
+    public void setBlacklist(Collection<String> blacklist) {
+        this.blacklist = blacklist;
+    }
+
+    @Override
+    public String toString() {
+        return "FilterConfig [blacklist=" + blacklist + "]";
+    }
+
+}

--- a/src/main/java/org/wikimedia/cassandra/metrics/service/Discover.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/service/Discover.java
@@ -49,6 +49,7 @@ public class Discover implements Job {
     private int interval;
     private String carbonHost;
     private int carbonPort;
+    private Object filter;
 
     @Override
     public void execute(JobExecutionContext context) throws JobExecutionException {
@@ -72,6 +73,7 @@ public class Discover implements Job {
                     dataMap.put("carbonHost", carbonHost);
                     dataMap.put("carbonPort", carbonPort);
                     dataMap.put("instanceName", jvm.getCassandraInstance());
+                    dataMap.put("filter", filter);
 
                     JobDetail job = JobBuilder.newJob(Collector.class)
                             .withIdentity(jvm.getCassandraInstance(), "collectionGroup")
@@ -126,10 +128,14 @@ public class Discover implements Job {
         this.carbonPort = carbonPort;
     }
 
+    public void setFilter(Object filter) {
+        this.filter = filter;
+    }
+
     @Override
     public String toString() {
         return "Discover [instances=" + instances + ", scheduler=" + scheduler + ", interval=" + interval + ", carbonHost="
-                + carbonHost + ", carbonPort=" + carbonPort + "]";
+                + carbonHost + ", carbonPort=" + carbonPort + ", filter=" + filter + "]";
     }
 
     private static Trigger newTrigger(String instance, int interval) {

--- a/src/test/java/org/wikimedia/cassandra/metrics/CarbonVisitorTest.java
+++ b/src/test/java/org/wikimedia/cassandra/metrics/CarbonVisitorTest.java
@@ -29,6 +29,8 @@ import javax.management.ObjectName;
 
 import org.junit.Test;
 
+import com.google.common.base.Optional;
+
 public class CarbonVisitorTest {
 
     @Test
@@ -46,7 +48,7 @@ public class CarbonVisitorTest {
             }
         };
 
-        CarbonVisitor visitor = new CarbonVisitor(carbon, "cassandra");
+        CarbonVisitor visitor = new CarbonVisitor(carbon, "cassandra", Optional.<Filter>absent());
 
         visitor.visit(new JmxSample(Type.JVM, new ObjectName("java.lang:type=Runtime"), "uptime", Integer.valueOf(1), 1));
 

--- a/src/test/java/org/wikimedia/cassandra/metrics/FilterTest.java
+++ b/src/test/java/org/wikimedia/cassandra/metrics/FilterTest.java
@@ -1,0 +1,40 @@
+/* Copyright 2015 Eric Evans <eevans@wikimedia.org> and Wikimedia Foundation
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wikimedia.cassandra.metrics;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+
+public class FilterTest {
+
+    @Test
+    public void test() {
+
+        Yaml yaml = new Yaml(new Constructor(FilterConfig.class));
+        FilterConfig config = (FilterConfig)yaml.load(getClass().getResourceAsStream("/filter-test.yaml"));
+        Filter filter = new Filter(config);
+
+        assertThat(filter.accept("acceptable.value"), is(true));
+        assertThat(filter.accept("blacklisted.metric.1MinuteRate"), is(false));
+        assertThat(filter.accept("blacklisted.metric.99Percentile"), is(false));
+
+    }
+
+}

--- a/src/test/resources/filter-test.yaml
+++ b/src/test/resources/filter-test.yaml
@@ -1,0 +1,3 @@
+blacklist:
+  - .*1MinuteRate$
+  - .*\.metric\.99Percentile$


### PR DESCRIPTION
Adds support for filtering the metrics sent to Carbon through the use of a YAML-formatted blacklist.