### PR TITLE
hack-in support for Cassandra 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - openjdk7
+  - oraclejdk8
 
 notifications:
   email:

--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@ cassandra-metrics-collector [![Build Status](https://travis-ci.org/wikimedia/cas
 ===========================
 
 Discovers running instances of Cassandra on the local machine, collects
-performance metrics (via JMX, using a domain socket), and writes them to
+performance metrics (via JMX), and writes them to
 [Graphite](https://github.com/graphite-project/graphite-web)/[Carbon](https://github.com/graphite-project/carbon)
 in a format compatible with the [Dropwizard metrics](http://metrics.dropwizard.io)
 GraphiteReporter.
@@ -81,3 +81,27 @@ Collect Cassandra metrics and write to netcat:
           --interval 15 \
           --carbon-host localhost \
           --carbon-port 2003 \
+
+Cassandra >= 2.2
+----------------
+Cassandra 2.2 broke backward compatibility by wrapping the
+[Dropwizard metrics](http://metrics.dropwizard.io) mbeans in delegators,
+(thus changing the name).  This service continues to default to Cassandra
+2.1 for the time-being (mostly because that is what the Wikimedia
+Foundation has standardized on).
+
+To enable support for Cassandra 2.2 you must start the service with the
+`-Dcassandra.version=v2_2` system property.  Additionally, since the uber
+jar does not currently contain the needed Cassandra class files, you cannot
+launch it as an executable jar, as described above.  To start the service
+and collect metrics for a Cassandra 2.2 instance, invoke Java using a
+classpath that contains your Cassandra 2.2.x jar file, and specify the
+main class as an argument.  For example:
+
+    $ export CLASSPATH=/path/to/apache-cassandra.jar:/path/to/cassandra-metrics-collector-<version>-jar-with-dependencies.jar
+    $ java -Dcassandra.version=v2_2 org.wikimedia.cassandra.metrics.service.Service \
+        --interval 15 \
+        --carbon-host localhost \
+        --carbon-port 2003
+
+*Note: You must disable `-XX:+PerfDisableSharedMem` in `cassandra-env.sh` for JVM auto-discovery to work (this will be fixed in a future release).*

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.wikimedia</groupId>
   <artifactId>cassandra-metrics-collector</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <name>Cassandra metrics collector</name>
   <description>JMX metrics collector for Apache Cassandra</description>
 
@@ -19,8 +19,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
@@ -63,18 +63,6 @@
       <version>18.0</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>1.10.19</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.sun</groupId>
       <artifactId>tools</artifactId>
       <version>1.8.0</version>
@@ -110,6 +98,26 @@
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
       <version>1.16</version>
+    </dependency>
+    <!-- Needed for CassandraMetricsRegistry -->
+    <dependency>
+      <groupId>org.apache.cassandra</groupId>
+      <artifactId>cassandra-all</artifactId>
+      <version>2.2.5</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/wikimedia/cassandra/metrics/Command.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/Command.java
@@ -41,7 +41,7 @@ public class Command {
             System.exit(1);
         }
 
-        try (JmxCollector collector = new JmxCollector(args[0], jmxPort)) {
+        try (JmxCollector collector = JmxCollectorFactory.create(args[0], jmxPort)) {
             if (Boolean.parseBoolean(System.getenv().get("DRY_RUN"))) {
                 collector.getSamples(new TsvVisitor(System.out, args[4]));
             }

--- a/src/main/java/org/wikimedia/cassandra/metrics/JmxCollector21.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/JmxCollector21.java
@@ -1,0 +1,181 @@
+/* Copyright 2015-2016 Eric Evans <eevans@wikimedia.org>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.wikimedia.cassandra.metrics;
+
+import static org.wikimedia.cassandra.metrics.Constants.DEFAULT_JMX_HOST;
+import static org.wikimedia.cassandra.metrics.Constants.DEFAULT_JMX_PORT;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.management.remote.JMXServiceURL;
+
+import org.wikimedia.cassandra.metrics.JmxSample.Type;
+
+import com.yammer.metrics.reporting.JmxReporter;
+
+
+@Deprecated
+public class JmxCollector21 extends JmxCollector {
+
+    static {
+        mbeanClasses = new HashMap<String, Class<?>>();
+        mbeanClasses.put("com.yammer.metrics.reporting.JmxReporter$Gauge", JmxReporter.GaugeMBean.class);
+        mbeanClasses.put("com.yammer.metrics.reporting.JmxReporter$Timer", JmxReporter.TimerMBean.class);
+        mbeanClasses.put("com.yammer.metrics.reporting.JmxReporter$Counter", JmxReporter.CounterMBean.class);
+        mbeanClasses.put("com.yammer.metrics.reporting.JmxReporter$Meter", JmxReporter.MeterMBean.class);
+        mbeanClasses.put("com.yammer.metrics.reporting.JmxReporter$Histogram", JmxReporter.HistogramMBean.class);
+        mbeanClasses.put("com.yammer.metrics.reporting.JmxReporter$Meter", JmxReporter.MeterMBean.class);
+
+        blacklist = new HashSet<ObjectName>();
+        blacklist.add(newObjectName("org.apache.cassandra.metrics:type=ColumnFamily,name=SnapshotsSize"));
+        blacklist.add(newObjectName("org.apache.cassandra.metrics:type=ColumnFamily,keyspace=system,scope=compactions_in_progress,name=SnapshotsSize"));
+
+    }
+
+    JmxCollector21() throws IOException {
+        super(DEFAULT_JMX_HOST);
+    }
+
+    JmxCollector21(String host) throws IOException {
+        super(host, DEFAULT_JMX_PORT);
+    }
+
+    JmxCollector21(String host, int port) throws IOException {
+        super(host, port);
+    }
+
+    JmxCollector21(JMXServiceURL jmxUrl) throws IOException {
+        super(jmxUrl);
+    }
+
+    public void getCassandraSamples(SampleVisitor visitor) throws IOException {
+
+        for (ObjectInstance instance : getConnection().queryMBeans(this.metricsObjectName, null)) {
+            if (!interesting(instance.getObjectName()))
+                continue;
+
+            Object proxy = getMBeanProxy(instance);
+            ObjectName oName = instance.getObjectName();
+
+            int timestamp = (int) (System.currentTimeMillis() / 1000);
+
+            // Order matters here (for example: TimerMBean extends MeterMBean)
+
+            if (proxy instanceof JmxReporter.TimerMBean) {
+                JmxReporter.TimerMBean timer = (JmxReporter.TimerMBean)proxy;
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "50percentile", timer.get50thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "75percentile", timer.get75thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "95percentile", timer.get95thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "98percentile", timer.get98thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "99percentile", timer.get99thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "999percentile", timer.get999thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "1MinuteRate", timer.getOneMinuteRate(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "5MinuteRate", timer.getFiveMinuteRate(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "15MinuteRate", timer.getFifteenMinuteRate(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "count", timer.getCount(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "max", timer.getMax(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "mean", timer.getMean(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "meanRate", timer.getMeanRate(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "min", timer.getMin(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "stddev", timer.getStdDev(), timestamp));
+                continue;
+            }
+
+            if (proxy instanceof JmxReporter.MeterMBean) {
+                JmxReporter.MeterMBean meter = (JmxReporter.MeterMBean)proxy;
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "15MinuteRate", meter.getFifteenMinuteRate(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "1MinuteRate", meter.getOneMinuteRate(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "5MinuteRate", meter.getFiveMinuteRate(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "count", meter.getCount(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "meanRate", meter.getMeanRate(), timestamp));
+                continue;
+            }
+
+            if (proxy instanceof JmxReporter.HistogramMBean) {
+                JmxReporter.HistogramMBean histogram = (JmxReporter.HistogramMBean)proxy;
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "50percentile", histogram.get50thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "75percentile", histogram.get75thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "95percentile", histogram.get95thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "98percentile", histogram.get98thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "99percentile", histogram.get99thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "999percentile", histogram.get999thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "max", histogram.getMax(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "mean", histogram.getMean(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "min", histogram.getMin(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "stddev", histogram.getStdDev(), timestamp));
+                continue;
+            }
+
+            if (proxy instanceof JmxReporter.GaugeMBean) {
+                // EstimatedRowSizeHistogram and EstimatedColumnCountHistogram are allegedly Gauge, but with a value
+                // of type of long[], we're left with little choice but to special-case them.  This borrows code from
+                // Cassandra to decode the array into a histogram (50p, 75p, 95p, 98p, 99p, min, and max).
+                String name = oName.getKeyProperty("name");
+                if (name.equals("EstimatedRowSizeHistogram") || name.equals("EstimatedColumnCountHistogram")) {
+                    Object value = ((JmxReporter.GaugeMBean) proxy).getValue();
+                    double[] percentiles = metricPercentilesAsArray((long[])value);
+                    visitor.visit(new JmxSample(Type.CASSANDRA, oName, "50percentile", percentiles[0], timestamp));
+                    visitor.visit(new JmxSample(Type.CASSANDRA, oName, "75percentile", percentiles[1], timestamp));
+                    visitor.visit(new JmxSample(Type.CASSANDRA, oName, "95percentile", percentiles[2], timestamp));
+                    visitor.visit(new JmxSample(Type.CASSANDRA, oName, "98percentile", percentiles[3], timestamp));
+                    visitor.visit(new JmxSample(Type.CASSANDRA, oName, "99percentile", percentiles[4], timestamp));
+                    visitor.visit(new JmxSample(Type.CASSANDRA, oName, "min", percentiles[5], timestamp));
+                    visitor.visit(new JmxSample(Type.CASSANDRA, oName, "max", percentiles[6], timestamp));
+                }
+                else {
+                    visitor.visit(new JmxSample(
+                            Type.CASSANDRA,
+                            oName,
+                            "value",
+                            ((JmxReporter.GaugeMBean) proxy).getValue(),
+                            timestamp));
+                }
+                continue;
+            }
+
+            if (proxy instanceof JmxReporter.CounterMBean) {
+                visitor.visit(new JmxSample(
+                        Type.CASSANDRA,
+                        oName,
+                        "count",
+                        ((JmxReporter.CounterMBean) proxy).getCount(),
+                        timestamp));
+                continue;
+            }
+        }
+
+    }
+
+    public static void main(String... args) throws IOException, Exception {
+
+        try (JmxCollector21 collector = new JmxCollector21("localhost", 7100)) {
+            SampleVisitor visitor = new SampleVisitor() {
+                @Override
+                public void visit(JmxSample jmxSample) {
+                    if (jmxSample.getObjectName().getKeyProperty("type").equals("ColumnFamily"))
+                        System.err.printf("%s,%s=%s%n", jmxSample.getObjectName(), jmxSample.getMetricName(), jmxSample.getValue());
+                }
+            };
+            collector.getSamples(visitor);
+        }
+
+    }
+
+}

--- a/src/main/java/org/wikimedia/cassandra/metrics/JmxCollector22.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/JmxCollector22.java
@@ -1,0 +1,176 @@
+/* Copyright 2015-2016 Eric Evans <eevans@wikimedia.org>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.wikimedia.cassandra.metrics;
+
+import static org.wikimedia.cassandra.metrics.Constants.DEFAULT_JMX_HOST;
+import static org.wikimedia.cassandra.metrics.Constants.DEFAULT_JMX_PORT;
+
+import java.io.IOException;
+import java.util.HashSet;
+
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.management.remote.JMXServiceURL;
+
+import org.apache.cassandra.metrics.CassandraMetricsRegistry;
+import org.wikimedia.cassandra.metrics.JmxSample.Type;
+
+
+public class JmxCollector22 extends JmxCollector {
+
+    static {
+        mbeanClasses.put("org.apache.cassandra.metrics.CassandraMetricsRegistry$JmxGauge", CassandraMetricsRegistry.JmxGaugeMBean.class);
+        mbeanClasses.put("org.apache.cassandra.metrics.CassandraMetricsRegistry$JmxTimer", CassandraMetricsRegistry.JmxTimerMBean.class);
+        mbeanClasses.put("org.apache.cassandra.metrics.CassandraMetricsRegistry$JmxCounter", CassandraMetricsRegistry.JmxCounterMBean.class);
+        mbeanClasses.put("org.apache.cassandra.metrics.CassandraMetricsRegistry$JmxMeter", CassandraMetricsRegistry.JmxMeterMBean.class);
+        mbeanClasses.put("org.apache.cassandra.metrics.CassandraMetricsRegistry$JmxHistogram", CassandraMetricsRegistry.JmxHistogramMBean.class);
+
+        blacklist = new HashSet<ObjectName>();
+        blacklist.add(newObjectName("org.apache.cassandra.metrics:type=ColumnFamily,name=SnapshotsSize"));
+        blacklist.add(newObjectName("org.apache.cassandra.metrics:type=ColumnFamily,keyspace=system,scope=compactions_in_progress,name=SnapshotsSize"));
+
+    }
+
+    JmxCollector22() throws IOException {
+        super(DEFAULT_JMX_HOST);
+    }
+
+    JmxCollector22(String host) throws IOException {
+        super(host, DEFAULT_JMX_PORT);
+    }
+
+    JmxCollector22(String host, int port) throws IOException {
+        super(host, port);
+    }
+
+     JmxCollector22(JMXServiceURL jmxUrl) throws IOException {
+        super(jmxUrl);
+    }
+
+    public void getCassandraSamples(SampleVisitor visitor) throws IOException {
+
+        for (ObjectInstance instance : getConnection().queryMBeans(this.metricsObjectName, null)) {
+            if (!interesting(instance.getObjectName()))
+                continue;
+
+            Object proxy = getMBeanProxy(instance);
+            ObjectName oName = instance.getObjectName();
+
+            int timestamp = (int) (System.currentTimeMillis() / 1000);
+
+            // Order matters here (for example: TimerMBean extends MeterMBean)
+            if (proxy instanceof CassandraMetricsRegistry.JmxTimerMBean) {
+                CassandraMetricsRegistry.JmxTimerMBean timer = (CassandraMetricsRegistry.JmxTimerMBean)proxy;
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "50percentile", timer.get50thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "75percentile", timer.get75thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "95percentile", timer.get95thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "98percentile", timer.get98thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "99percentile", timer.get99thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "999percentile", timer.get999thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "1MinuteRate", timer.getOneMinuteRate(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "5MinuteRate", timer.getFiveMinuteRate(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "15MinuteRate", timer.getFifteenMinuteRate(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "count", timer.getCount(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "max", timer.getMax(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "mean", timer.getMean(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "meanRate", timer.getMeanRate(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "min", timer.getMin(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "stddev", timer.getStdDev(), timestamp));
+                continue;
+            }
+
+            if (proxy instanceof CassandraMetricsRegistry.JmxMeterMBean) {
+                CassandraMetricsRegistry.JmxMeterMBean meter = (CassandraMetricsRegistry.JmxMeterMBean)proxy;
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "15MinuteRate", meter.getFifteenMinuteRate(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "1MinuteRate", meter.getOneMinuteRate(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "5MinuteRate", meter.getFiveMinuteRate(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "count", meter.getCount(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "meanRate", meter.getMeanRate(), timestamp));
+                continue;
+            }
+
+            if (proxy instanceof CassandraMetricsRegistry.JmxHistogramMBean) {
+                CassandraMetricsRegistry.JmxHistogramMBean histogram = (CassandraMetricsRegistry.JmxHistogramMBean)proxy;
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "50percentile", histogram.get50thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "75percentile", histogram.get75thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "95percentile", histogram.get95thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "98percentile", histogram.get98thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "99percentile", histogram.get99thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "999percentile", histogram.get999thPercentile(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "max", histogram.getMax(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "mean", histogram.getMean(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "min", histogram.getMin(), timestamp));
+                visitor.visit(new JmxSample(Type.CASSANDRA, oName, "stddev", histogram.getStdDev(), timestamp));
+                continue;
+            }
+
+            if (proxy instanceof CassandraMetricsRegistry.JmxGaugeMBean) {
+                // EstimatedRowSizeHistogram and EstimatedColumnCountHistogram are allegedly Gauge, but with a value
+                // of type of long[], we're left with little choice but to special-case them.  This borrows code from
+                // Cassandra to decode the array into a histogram (50p, 75p, 95p, 98p, 99p, min, and max).
+                String name = oName.getKeyProperty("name");
+                if (name.equals("EstimatedRowSizeHistogram") || name.equals("EstimatedColumnCountHistogram")) {
+                    Object value = ((CassandraMetricsRegistry.JmxGaugeMBean) proxy).getValue();
+                    double[] percentiles = metricPercentilesAsArray((long[])value);
+                    visitor.visit(new JmxSample(Type.CASSANDRA, oName, "50percentile", percentiles[0], timestamp));
+                    visitor.visit(new JmxSample(Type.CASSANDRA, oName, "75percentile", percentiles[1], timestamp));
+                    visitor.visit(new JmxSample(Type.CASSANDRA, oName, "95percentile", percentiles[2], timestamp));
+                    visitor.visit(new JmxSample(Type.CASSANDRA, oName, "98percentile", percentiles[3], timestamp));
+                    visitor.visit(new JmxSample(Type.CASSANDRA, oName, "99percentile", percentiles[4], timestamp));
+                    visitor.visit(new JmxSample(Type.CASSANDRA, oName, "min", percentiles[5], timestamp));
+                    visitor.visit(new JmxSample(Type.CASSANDRA, oName, "max", percentiles[6], timestamp));
+                }
+                else {
+                    visitor.visit(new JmxSample(
+                            Type.CASSANDRA,
+                            oName,
+                            "value",
+                            ((CassandraMetricsRegistry.JmxGaugeMBean) proxy).getValue(),
+                            timestamp));
+                }
+                continue;
+            }
+
+            if ((proxy instanceof CassandraMetricsRegistry.JmxCounterMBean) || (proxy instanceof CassandraMetricsRegistry.JmxCounterMBean)) {
+
+                visitor.visit(new JmxSample(
+                        Type.CASSANDRA,
+                        oName,
+                        "count",
+                        ((CassandraMetricsRegistry.JmxCounterMBean) proxy).getCount(),
+                        timestamp));
+                continue;
+            }
+        }
+
+    }
+
+    public static void main(String... args) throws IOException, Exception {
+
+        try (JmxCollector22 collector = new JmxCollector22("localhost", 7100)) {
+            SampleVisitor visitor = new SampleVisitor() {
+                @Override
+                public void visit(JmxSample jmxSample) {
+                    if (jmxSample.getObjectName().getKeyProperty("type").equals("ColumnFamily"))
+                        System.err.printf("%s,%s=%s%n", jmxSample.getObjectName(), jmxSample.getMetricName(), jmxSample.getValue());
+                }
+            };
+            collector.getSamples(visitor);
+        }
+
+    }
+
+}

--- a/src/main/java/org/wikimedia/cassandra/metrics/JmxCollectorFactory.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/JmxCollectorFactory.java
@@ -1,0 +1,92 @@
+/* Copyright 2016 Eric Evans <eevans@wikimedia.org>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.wikimedia.cassandra.metrics;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+
+import javax.management.remote.JMXServiceURL;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JmxCollectorFactory {
+
+    public static enum CassandraVersion {
+        V2_1, V2_2;
+    }
+
+    public static final CassandraVersion DEFAULT_VERSION = CassandraVersion.V2_1;
+
+    private static final Logger LOG = LoggerFactory.getLogger(JmxCollectorFactory.class);
+
+    private static CassandraVersion versionFromSystemProperty() {
+        String property = System.getProperty("cassandra.version");
+        try {
+            return (property != null) ? CassandraVersion.valueOf(property.toUpperCase()) : DEFAULT_VERSION;
+        }
+        catch (IllegalArgumentException e) {
+            LOG.warn(
+                    "cassandra-version value {} unrecognized, using default of {} instead",
+                    property,
+                    DEFAULT_VERSION.toString());
+        }
+        return DEFAULT_VERSION;
+    }
+
+    public static JmxCollector create() throws IOException {
+        return create(versionFromSystemProperty(), Constants.DEFAULT_JMX_HOST);
+    }
+
+    public static JmxCollector create(String host, int port) throws IOException {
+        return create(versionFromSystemProperty(), host, port);
+    }
+
+    public static JmxCollector create(JMXServiceURL url) throws IOException {
+        return create(versionFromSystemProperty(), url);
+    }
+
+    public static JmxCollector create(CassandraVersion version) throws IOException {
+        return create(version, Constants.DEFAULT_JMX_HOST);
+    }
+
+    public static JmxCollector create(CassandraVersion version, String host) throws IOException {
+        return create(version, host, Constants.DEFAULT_JMX_PORT);
+    }
+
+    public static JmxCollector create(CassandraVersion version, String host, int port) throws IOException {
+        JMXServiceURL jmxUrl;
+        try {
+            jmxUrl = new JMXServiceURL(String.format(JmxCollector.FORMAT_URL, host, port));
+        }
+        catch (MalformedURLException e) {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+        return create(version, jmxUrl);
+    }
+
+    @SuppressWarnings("deprecation")
+    public static JmxCollector create(CassandraVersion version, JMXServiceURL url) throws IOException {
+        switch (version) {
+        case V2_1:
+            return new JmxCollector21(url);
+        case V2_2:
+            return new JmxCollector22(url);
+        default:
+            throw new RuntimeException("Unexpected version; A bug!");
+        }
+    }
+}

--- a/src/main/java/org/wikimedia/cassandra/metrics/service/Collector.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/service/Collector.java
@@ -30,6 +30,7 @@ import org.wikimedia.cassandra.metrics.CarbonVisitor;
 import org.wikimedia.cassandra.metrics.Discovery;
 import org.wikimedia.cassandra.metrics.Filter;
 import org.wikimedia.cassandra.metrics.JmxCollector;
+import org.wikimedia.cassandra.metrics.JmxCollectorFactory;
 
 import com.google.common.base.Optional;
 
@@ -51,13 +52,13 @@ public class Collector implements Job {
     public void execute(JobExecutionContext context) throws JobExecutionException {
         LOG.debug("Connection to {}", this.jvm.getJmxUrl());
 
-        try (JmxCollector j = new JmxCollector(this.jvm.getJmxUrl())) {
+        try (JmxCollector c = JmxCollectorFactory.create(this.jvm.getJmxUrl())) {
             LOG.debug("Connected to {}", this.jvm.getJmxUrl());
             LOG.debug("Connecting to {}:{}", this.carbonHost, this.carbonPort);
 
             try (CarbonVisitor v = new CarbonVisitor(this.carbonHost, this.carbonPort, prefix(this.instanceName), filter)) {
                 LOG.debug("Collecting...");
-                j.getSamples(v);
+                c.getSamples(v);
             }
             catch (CarbonException e) {
                 LOG.error("Carbon Error", e);
@@ -105,7 +106,7 @@ public class Collector implements Job {
     }
 
     public void setFilter(Object filter) {
-        this.filter = (filter != null) ? Optional.of((Filter)filter) : Optional.<Filter>absent();
+        this.filter = (filter != null) ? Optional.of((Filter) filter) : Optional.<Filter> absent();
     }
 
     @Override

--- a/src/main/java/org/wikimedia/cassandra/metrics/service/Discover.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/service/Discover.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wikimedia.cassandra.metrics.Discovery;
 import org.wikimedia.cassandra.metrics.JmxCollector;
+import org.wikimedia.cassandra.metrics.JmxCollectorFactory;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
@@ -61,7 +62,7 @@ public class Discover implements Job {
                 LOG.info("Found instance {}", jvm.getCassandraInstance());
                 LOG.debug("Verifying JMX connectivity...");
 
-                try (JmxCollector c = new JmxCollector(jvm.getJmxUrl())) {
+                try (JmxCollector c = JmxCollectorFactory.create(jvm.getJmxUrl())) {
                     // I don't know how this would happen, so it probably will.
                     if (jobs.contains(jvm.getCassandraInstance())) {
                         LOG.warn("Discovered instance with a matching job ({}); What gives?", jvm.getCassandraInstance());


### PR DESCRIPTION
Somewhere between 2.1.13, and 2.2.5, Cassandra was refactored to wrap all of the codahale/dropwizard metric mbeans in Cassandra delegators.  This would have been awesome if it were done this way from the beginning, but after-the-fact it broke cmcd by changing the object names of everything.

In order to retain compatibility with the 2.1 series, this changeset introduces a second collector class (a 2.2-specific one), and uses a factory (*gasp*) to create instances of either based on the version (which for now has to be passed along via a system property).

This is unpleasant, but can be backed out rather easily after we no longer have a need for Cassandra 2.1 compatibility.

Bug: https://phabricator.wikimedia.org/T126629