### PR TITLE
Port to Cassandra 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - openjdk7
+  - oraclejdk8
 
 notifications:
   email:

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,9 @@
 cassandra-metrics-collector [![Build Status](https://travis-ci.org/wikimedia/cassandra-metrics-collector.svg?branch=master)](https://travis-ci.org/wikimedia/cassandra-metrics-collector)
 ===========================
 
+*Note: This branch supports Cassandra >= 2.2 (tested with 2.2.5).  For Cassandra 2.1,
+please use [this branch](https://github.com/wikimedia/cassandra-metrics-collector/tree/2.0.0).*
+
 Discovers running instances of Cassandra on the local machine, collects
 performance metrics (via JMX, using a domain socket), and writes them to
 [Graphite](https://github.com/graphite-project/graphite-web)/[Carbon](https://github.com/graphite-project/carbon)
@@ -42,8 +45,9 @@ Run
                         Carbon port number (default: 2003)
 
 For example:
-    
-    $ java -jar cassandra-metrics-collector-<version>-jar-with-dependencies.jar \
+
+    $ export CLASSPATH=/path/to/apache-cassandra.jar:/path/to/cassandra-metrics-collector-<version>-jar-with-dependencies.jar
+    $ java org.wikimedia.cassandra.metrics.service.Service \
             --interval 60 \
             --carbon-host carbon-1.example.com \
             --carbon-port 2003 \
@@ -54,12 +58,14 @@ Simple invocation
 It is also possible to invoke a single collection cycle against a specific
 instance over TCP.
 
-    $ java -cp target/cassandra-metrics-collector-<version>-jar-with-dependencies.jar org.wikimedia.cassandra.metrics.Command
+    $ export CLASSPATH=/path/to/apache-cassandra.jar:/path/to/cassandra-metrics-collector-<version>-jar-with-dependencies.jar
+    $ java org.wikimedia.cassandra.metrics.Command
     Usage: Command <jmx host> <jmx port> <graphite host> <graphite port> <prefix>
 
 For example:
 
-    $ java -cp target/cassandra-metrics-collector-<version>-jar-with-dependencies.jar org.wikimedia.cassandra.metrics.Command \
+    $ export CLASSPATH=/path/to/apache-cassandra.jar:/path/to/cassandra-metrics-collector-<version>-jar-with-dependencies.jar
+    $ java -cp org.wikimedia.cassandra.metrics.Command \
           db-1.example.com \
           7199 \
           carbon-1.example.com \
@@ -77,7 +83,8 @@ Open a socket and listen on port 2003:
 
 Collect Cassandra metrics and write to netcat:
 
-    $ java -jar cassandra-metrics-collector-<version>-jar-with-dependencies.jar \
+    $ export CLASSPATH=/path/to/apache-cassandra.jar:/path/to/cassandra-metrics-collector-<version>-jar-with-dependencies.jar
+    $ java org.wikimedia.cassandra.metrics.service.Service \
           --interval 15 \
           --carbon-host localhost \
           --carbon-port 2003 \

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.wikimedia</groupId>
   <artifactId>cassandra-metrics-collector</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <name>Cassandra metrics collector</name>
   <description>JMX metrics collector for Apache Cassandra</description>
 
@@ -19,8 +19,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
@@ -53,9 +53,10 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.yammer.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>2.2.0</version>
+      <groupId>org.apache.cassandra</groupId>
+      <artifactId>cassandra-all</artifactId>
+      <version>2.2.5</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Somewhere between 2.1.13, and 2.2.5, Cassandra was refactored to wrap all of the codahale/dropwizard metric mbeans in Cassandra delegators.  This would have been awesome if it were done this way from the beginning, but after-the-fact it broke cmcd by changing the object names of everything.

This is an alternative to what was proposed in wikimedia/cassandra-metrics-collector/pull/7.  Instead of supporting both versions with a JmxCollectorFactory, this changeset eschews 2.1 compat, (and is simpler as a result).

Also worth mentioning.  This *does not* bundle Cassandra as a dependency in the uber jar.  As a result, you cannot use this as an executable jar (ala `java -jar <jar>`), but must instead construct a classpath that contains both this jar, and Cassandra (typically `/usr/share/cassandra/lib/apache-cassandra.jar` on Debian installs).  This is also the case for "2.2 mode" over in wikimedia/cassandra-metrics-collector/pull/7, FWIW.

Building a complete uber jar containing all of Cassandra bloated things quite a bit, and seemed like it could make this unnecessarily brittle in the face of other Cassandra versions.  It might be possible to use a minimal subset of Cassandra classes in a shaded jar though, if anyone thinks this is a problem.

Bug: https://phabricator.wikimedia.org/T126629