### PR TITLE
Whitelist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - openjdk7
+  - oraclejdk8
 
 notifications:
   email:

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,9 @@
 cassandra-metrics-collector [![Build Status](https://travis-ci.org/wikimedia/cassandra-metrics-collector.svg?branch=master)](https://travis-ci.org/wikimedia/cassandra-metrics-collector)
 ===========================
 
+*Note: This branch supports Cassandra >= 2.2 (tested with 2.2.5).  For Cassandra 2.1,
+please use [this branch](https://github.com/wikimedia/cassandra-metrics-collector/tree/2.0.0).*
+
 Discovers running instances of Cassandra on the local machine, collects
 performance metrics (via JMX, using a domain socket), and writes them to
 [Graphite](https://github.com/graphite-project/graphite-web)/[Carbon](https://github.com/graphite-project/carbon)
@@ -42,8 +45,9 @@ Run
                         Carbon port number (default: 2003)
 
 For example:
-    
-    $ java -jar cassandra-metrics-collector-<version>-jar-with-dependencies.jar \
+
+    $ export CLASSPATH=/path/to/apache-cassandra.jar:/path/to/cassandra-metrics-collector-<version>-jar-with-dependencies.jar
+    $ java org.wikimedia.cassandra.metrics.service.Service \
             --interval 60 \
             --carbon-host carbon-1.example.com \
             --carbon-port 2003 \
@@ -54,12 +58,14 @@ Simple invocation
 It is also possible to invoke a single collection cycle against a specific
 instance over TCP.
 
-    $ java -cp target/cassandra-metrics-collector-<version>-jar-with-dependencies.jar org.wikimedia.cassandra.metrics.Command
+    $ export CLASSPATH=/path/to/apache-cassandra.jar:/path/to/cassandra-metrics-collector-<version>-jar-with-dependencies.jar
+    $ java org.wikimedia.cassandra.metrics.Command
     Usage: Command <jmx host> <jmx port> <graphite host> <graphite port> <prefix>
 
 For example:
 
-    $ java -cp target/cassandra-metrics-collector-<version>-jar-with-dependencies.jar org.wikimedia.cassandra.metrics.Command \
+    $ export CLASSPATH=/path/to/apache-cassandra.jar:/path/to/cassandra-metrics-collector-<version>-jar-with-dependencies.jar
+    $ java -cp org.wikimedia.cassandra.metrics.Command \
           db-1.example.com \
           7199 \
           carbon-1.example.com \
@@ -77,7 +83,8 @@ Open a socket and listen on port 2003:
 
 Collect Cassandra metrics and write to netcat:
 
-    $ java -jar cassandra-metrics-collector-<version>-jar-with-dependencies.jar \
+    $ export CLASSPATH=/path/to/apache-cassandra.jar:/path/to/cassandra-metrics-collector-<version>-jar-with-dependencies.jar
+    $ java org.wikimedia.cassandra.metrics.service.Service \
           --interval 15 \
           --carbon-host localhost \
           --carbon-port 2003 \

--- a/filter-sample.yaml
+++ b/filter-sample.yaml
@@ -1,3 +1,6 @@
+whitelist:
+  - .*\.wanted.meanRate$
+
 blacklist:
   - .*\.meanRate$
   - .*\.50percentile$

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.wikimedia</groupId>
   <artifactId>cassandra-metrics-collector</artifactId>
-  <version>3.0.0-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <name>Cassandra metrics collector</name>
   <description>JMX metrics collector for Apache Cassandra</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.wikimedia</groupId>
   <artifactId>cassandra-metrics-collector</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <name>Cassandra metrics collector</name>
   <description>JMX metrics collector for Apache Cassandra</description>
 
@@ -19,8 +19,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
@@ -53,9 +53,10 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.yammer.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-      <version>2.2.0</version>
+      <groupId>org.apache.cassandra</groupId>
+      <artifactId>cassandra-all</artifactId>
+      <version>2.2.5</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/src/main/java/org/wikimedia/cassandra/metrics/FilterConfig.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/FilterConfig.java
@@ -15,21 +15,31 @@
 package org.wikimedia.cassandra.metrics;
 
 import java.util.Collection;
+import java.util.Collections;
 
 public class FilterConfig {
     private Collection<String> blacklist;
+    private Collection<String> whitelist;
 
     public Collection<String> getBlacklist() {
-        return blacklist;
+        return (blacklist != null) ? blacklist : Collections.emptyList();
     }
 
     public void setBlacklist(Collection<String> blacklist) {
         this.blacklist = blacklist;
     }
 
+    public Collection<String> getWhitelist() {
+        return (whitelist != null) ? whitelist : Collections.emptyList();
+    }
+
+    public void setWhitelist(Collection<String> whitelist) {
+        this.whitelist = whitelist;
+    }
+
     @Override
     public String toString() {
-        return "FilterConfig [blacklist=" + blacklist + "]";
+        return "FilterConfig [blacklist=" + blacklist + ", whitelist=" + whitelist + "]";
     }
 
 }

--- a/src/test/java/org/wikimedia/cassandra/metrics/FilterTest.java
+++ b/src/test/java/org/wikimedia/cassandra/metrics/FilterTest.java
@@ -35,6 +35,9 @@ public class FilterTest {
         assertThat(filter.accept("blacklisted.metric.1MinuteRate"), is(false));
         assertThat(filter.accept("blacklisted.metric.99Percentile"), is(false));
 
+        // This one should be white listed
+        assertThat(filter.accept("blacklisted.wanted.metric.99Percentile"), is(true));
+
     }
 
 }

--- a/src/test/resources/filter-test.yaml
+++ b/src/test/resources/filter-test.yaml
@@ -1,3 +1,7 @@
+
+whitelist:
+  - .*\.wanted\.metric\.99Percentile$
+
 blacklist:
   - .*1MinuteRate$
   - .*\.metric\.99Percentile$


### PR DESCRIPTION
We want to be able to filter out all but a few metrics for some tables (see [T134016#2261407](https://phabricator.wikimedia.org/T134016#2261407)).  This changeset introduces whitelisting which will make that easier / more maintainable (i.e. we can whitelist the select metrics we are interested in, and then blacklist `.*\.metrics\.ColumnFamily\.local_.+\.meta\.`).