### PR TITLE
Add support for whitelist

### DIFF
--- a/filter-sample.yaml
+++ b/filter-sample.yaml
@@ -1,3 +1,6 @@
+whitelist:
+  - .*\.wanted.meanRate$
+
 blacklist:
   - .*\.meanRate$
   - .*\.50percentile$

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.wikimedia</groupId>
   <artifactId>cassandra-metrics-collector</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <name>Cassandra metrics collector</name>
   <description>JMX metrics collector for Apache Cassandra</description>
 

--- a/src/main/java/org/wikimedia/cassandra/metrics/FilterConfig.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/FilterConfig.java
@@ -15,21 +15,31 @@
 package org.wikimedia.cassandra.metrics;
 
 import java.util.Collection;
+import java.util.Collections;
 
 public class FilterConfig {
     private Collection<String> blacklist;
+    private Collection<String> whitelist;
 
     public Collection<String> getBlacklist() {
-        return blacklist;
+        return (blacklist != null) ? blacklist : Collections.<String>emptyList();
     }
 
     public void setBlacklist(Collection<String> blacklist) {
         this.blacklist = blacklist;
     }
 
+    public Collection<String> getWhitelist() {
+        return (whitelist != null) ? whitelist : Collections.<String>emptyList();
+    }
+
+    public void setWhitelist(Collection<String> whitelist) {
+        this.whitelist = whitelist;
+    }
+
     @Override
     public String toString() {
-        return "FilterConfig [blacklist=" + blacklist + "]";
+        return "FilterConfig [blacklist=" + blacklist + ", whitelist=" + whitelist + "]";
     }
 
 }

--- a/src/test/java/org/wikimedia/cassandra/metrics/FilterTest.java
+++ b/src/test/java/org/wikimedia/cassandra/metrics/FilterTest.java
@@ -35,6 +35,9 @@ public class FilterTest {
         assertThat(filter.accept("blacklisted.metric.1MinuteRate"), is(false));
         assertThat(filter.accept("blacklisted.metric.99Percentile"), is(false));
 
+        // This one should be white listed
+        assertThat(filter.accept("blacklisted.wanted.metric.99Percentile"), is(true));
+
     }
 
 }

--- a/src/test/resources/filter-test.yaml
+++ b/src/test/resources/filter-test.yaml
@@ -1,3 +1,7 @@
+
+whitelist:
+  - .*\.wanted\.metric\.99Percentile$
+
 blacklist:
   - .*1MinuteRate$
   - .*\.metric\.99Percentile$


### PR DESCRIPTION
We want to be able to filter out all but a few metrics for some tables (see [T134016#2261407](https://phabricator.wikimedia.org/T134016#2261407)).  This changeset introduces whitelisting which will make that easier / more maintainable (i.e. we can whitelist the select metrics we are interested in, and then blacklist `.*\.metrics\.ColumnFamily\.local_.+\.meta\.`).

This is the same as wikimedia/cassandra-metrics-collector/pull/9, but for the 2.x branch (sans the recent changes to support 2.2).