### PR TITLE
timeout long running jobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.wikimedia</groupId>
   <artifactId>cassandra-metrics-collector</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <name>Cassandra metrics collector</name>
   <description>JMX metrics collector for Apache Cassandra</description>
 

--- a/src/main/java/org/wikimedia/cassandra/metrics/service/Discover.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/service/Discover.java
@@ -74,6 +74,7 @@ public class Discover implements Job {
                     dataMap.put("carbonPort", carbonPort);
                     dataMap.put("instanceName", jvm.getCassandraInstance());
                     dataMap.put("filter", filter);
+                    dataMap.put("interval", interval);
 
                     JobDetail job = JobBuilder.newJob(Collector.class)
                             .withIdentity(jvm.getCassandraInstance(), "collectionGroup")

--- a/src/main/java/org/wikimedia/cassandra/metrics/service/Service.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/service/Service.java
@@ -111,7 +111,7 @@ public class Service {
                 .build();
         
         // Setup discovery.
-        
+
         // The discovery job periodically looks for new instances, and schedules
         // recurring collection tasks for any it finds.
         JobDataMap discoverMap = new JobDataMap();
@@ -140,7 +140,8 @@ public class Service {
         statsMap.put("carbonHost", carbonHost);
         statsMap.put("carbonPort", carbonPort);
         statsMap.put("stats", stats);
-        
+        statsMap.put("interval", interval);
+
         JobDetail statsJob = newJob(StatsReporter.class)
                 .withIdentity("reporterJob", "reportGroup")
                 .usingJobData(statsMap)

--- a/src/main/java/org/wikimedia/cassandra/metrics/service/TimedTask.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/service/TimedTask.java
@@ -1,0 +1,74 @@
+/* Copyright 2016 Eric Evans <eevans@wikimedia.org> and Wikimedia Foundation
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wikimedia.cassandra.metrics.service;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class TimedTask<T> {
+
+    private final int timeout;
+
+    /**
+     * Creates a new {@link TimedTask} instance for a given timeout.
+     *
+     * @param timeout
+     *            the timeout, in seconds
+     */
+    public TimedTask(int timeout) {
+        this.timeout = timeout;
+    }
+
+    /**
+     * Executes a {@link Callable}, returning the result, or raising an exception on timeout.
+     * 
+     * @param callable
+     *            the callable to execute
+     * @return
+     * @throws TimedTaskException
+     */
+    public T submit(Callable<T> callable) throws TimedTaskException {
+
+        T result = null;
+        ExecutorService service = Executors.newSingleThreadExecutor();
+        Future<T> future = service.submit(callable);
+
+        try {
+            result = future.get(this.timeout, TimeUnit.SECONDS);
+        }
+        catch (InterruptedException e) {
+            future.cancel(true);
+            throw new TimedTaskException("Task execution interrupted", e);
+        }
+        catch (ExecutionException e) {
+            future.cancel(true);
+            throw new TimedTaskException("Task execution exception", e);
+        }
+        catch (TimeoutException e) {
+            future.cancel(true);
+            throw new TimedTaskException(String.format("Timeout of %d seconds exceeded", this.timeout));
+        }
+        finally {
+            service.shutdown();
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/org/wikimedia/cassandra/metrics/service/TimedTaskException.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/service/TimedTaskException.java
@@ -1,0 +1,29 @@
+/* Copyright 2016 Eric Evans <eevans@wikimedia.org> and Wikimedia Foundation
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wikimedia.cassandra.metrics.service;
+
+public class TimedTaskException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public TimedTaskException(String message) {
+        super(message);
+    }
+
+    public TimedTaskException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/test/java/org/wikimedia/cassandra/metrics/service/TimedTaskTest.java
+++ b/src/test/java/org/wikimedia/cassandra/metrics/service/TimedTaskTest.java
@@ -1,0 +1,86 @@
+/* Copyright 2016 Eric Evans <eevans@wikimedia.org> and Wikimedia Foundation
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wikimedia.cassandra.metrics.service;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+import org.wikimedia.cassandra.metrics.CarbonException;
+
+public class TimedTaskTest {
+
+    @Test
+    public void test() throws TimedTaskException {
+        final AtomicBoolean called = new AtomicBoolean(false);
+
+        new TimedTask<Void>(1).submit(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                called.set(true);
+                return null;
+            }
+        });
+
+        assertThat(called.get(), is(true));
+    }
+
+    @Test
+    public void testException() {
+        try {
+            new TimedTask<Void>(1).submit(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    throw new CarbonException("oh noes");
+                }
+            });
+        }
+        catch (TimedTaskException e) {
+            assertThat(e.getCause(), instanceOf(ExecutionException.class));
+            assertThat(e.getCause().getCause(), instanceOf(CarbonException.class));
+            return;
+        }
+
+        fail("TimedTask failed to throw expected exception");
+    }
+
+    @Test
+    public void testTimeout() {
+        try {
+            new TimedTask<Void>(1).submit(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    Thread.sleep(1100);
+                    return null;
+                }
+            });
+
+            fail("TimedTask failed to throw expected exception");
+        }
+        catch (TimedTaskException e) {
+            assertThat(e.getCause(), equalTo(null));
+            return;
+        }
+
+    }
+
+}


### PR DESCRIPTION
There is evidence to suggest that cmcd jobs are blocking for long periods of
time while writing to Carbon (presumably because of issues with Carbon).  When
this happens, the jobs begin piling up locally.

At a minimum, it seems unwise to allow issues with the remote-side to create an
unbounded number of in-flight jobs.  Additionally, if the remote is struggling,
it is likely counter-productive to ratchet up the concurrency in an attempt at
storing every last metric.

This changeset introduces a TimedTask object which is used to run collections,
raising an exception and terminating the job if it runs for longer than the
configured collection interval, or 60 seconds, whichever is smaller.