### PR TITLE
Add Client and Keyspace to interesting types

### DIFF
--- a/src/main/java/org/wikimedia/cassandra/metrics/JmxCollector.java
+++ b/src/main/java/org/wikimedia/cassandra/metrics/JmxCollector.java
@@ -284,6 +284,7 @@ public class JmxCollector implements AutoCloseable {
     /* TODO: Ideally, the "interesting" criteria should be configurable. */
     private static Set<String> interestingTypes = Sets.newHashSet(
             "Cache",
+            "Client",
             "ClientRequest",
             "ColumnFamily",
             "Connection",
@@ -292,6 +293,7 @@ public class JmxCollector implements AutoCloseable {
             "FileCache",
             "IndexColumnFamily",
             "Storage",
+            "Keyspace",
             "ThreadPools",
             "Compaction",
             "ReadRepair",


### PR DESCRIPTION
The Client namespace contains metrics for connectedNativeClients
The Keyspace namespace contains aggregated metrics per keyspace


Note: This has only been tested on Cassandra 2.1.9